### PR TITLE
✨ Add command for release signers to easily import keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Backup files, redundant with git history
+/gpg/*~

--- a/cli.sh
+++ b/cli.sh
@@ -52,7 +52,7 @@ nodejs_keys_add() {
 
   KEY_ID="$1"
 
-  gpg --export --armor "${KEY_ID}" > "keys/${KEY_ID}.asc"
+  gpg --export --armor "${KEY_ID}" > "${CLI_DIR}/keys/${KEY_ID}.asc"
 
   GNUPGHOME="${CLI_DIR}/gpg" gpg --import "${CLI_DIR}/keys/${KEY_ID}.asc"
 
@@ -63,7 +63,7 @@ nodejs_keys_add() {
 
 nodejs_keys_usage() {
   >&2 cat <<EOF
-USAGE: $0 clear|help|import
+USAGE: $0 clear|help|import|add
 
 Manages Node.js release signing keys.
 

--- a/cli.sh
+++ b/cli.sh
@@ -56,7 +56,10 @@ nodejs_keys_add() {
 
   GNUPGHOME="${CLI_DIR}/gpg" gpg --import "${CLI_DIR}/keys/${KEY_ID}.asc"
 
+  printf "keys.list <- "
   if grep --quiet "${KEY_ID}" "${CLI_DIR}/keys.list"; then
+    echo "${KEY_ID}"
+  else
     echo "${KEY_ID}" | tee -a "${CLI_DIR}/keys.list"
   fi
 }

--- a/cli.sh
+++ b/cli.sh
@@ -45,6 +45,22 @@ nodejs_keys_import() {
   done
 }
 
+nodejs_keys_add() {
+  if [ $# -lt 1 ]; then
+    nodejs_keys_usage
+  fi
+
+  KEY_ID="$1"
+
+  gpg --export --armor "${KEY_ID}" > "keys/${KEY_ID}.asc"
+
+  GNUPGHOME="${CLI_DIR}/gpg" gpg --import "${CLI_DIR}/keys/${KEY_ID}.asc"
+
+  if grep --quiet "${KEY_ID}" "${CLI_DIR}/keys.list"; then
+    echo "${KEY_ID}" | tee -a "${CLI_DIR}/keys.list"
+  fi
+}
+
 nodejs_keys_usage() {
   >&2 cat <<EOF
 USAGE: $0 clear|help|import
@@ -56,6 +72,7 @@ COMMANDS:
   clear   Clears all Node.js release signing keys from the GPG keyring.
   help    Displays this help message.
   import  Imports all Node.js release signing keys to the GPG keyring. (default)
+  add     Adds a release signing key to this repo.
 
 EOF
   exit 1
@@ -83,6 +100,7 @@ COMMAND_NAME="help"
 
 if [ "$#" -gt 0 ]; then
   COMMAND_NAME="$1"
+  shift
 fi
 
 case "${COMMAND_NAME}" in
@@ -91,6 +109,9 @@ case "${COMMAND_NAME}" in
     ;;
   import)
      nodejs_keys_import
+    ;;
+  add)
+    nodejs_keys_add "$@"
     ;;
   *)
     nodejs_keys_usage


### PR DESCRIPTION
Supercedes #6.

This changeset introduces an "add" command that can be used by
the Node.js release signing team to add or update their own
release signing keys.

```
$ ./cli.sh add <signing-key-id>
```

For example: `./cli.sh add 4ED778F539E3634C779C87C6D7062848A1AB005C`

After this command has been added, members of the release signing
team can create PRs to update their own keys as follows:

 1. Clone the latest default branch (e.g: `master`) and create a feature branch.
 2. For each release signing key you have used or intend to use: run `./cli.sh add <key-id>` with the full key ID.
 3. Manually update README.md, as needed.
 4. Commit the result, push to the feature branch, and create a PR to have that merged into the default branch.