### PR TITLE
ci: fix `paths` filter

### DIFF
--- a/.github/workflows/verify-key-signature.yml
+++ b/.github/workflows/verify-key-signature.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - keys/
+      - .github/workflows/verify-key-signature.yml
+      - keys/**
   push:
     branches:
       - main
     paths:
-      - keys/
+      - .github/workflows/verify-key-signature.yml
+      - keys/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
I noticed the job wasn't run in https://github.com/nodejs/release-keys/pull/44, looks like `paths` validates on the full relative path of the changed files, listing the folder name does not produce the expected result.